### PR TITLE
Add gawk as a dependency to fix test failure

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -6,7 +6,7 @@
 export ZOPEN_TYPE="TARBALL"
 
 export ZOPEN_TARBALL_URL="https://ftp.gnu.org/gnu/automake/automake-1.16.tar.gz"
-export ZOPEN_TARBALL_DEPS="curl gzip make m4 perl autoconf tar coreutils"
+export ZOPEN_TARBALL_DEPS="curl gzip make m4 perl autoconf tar coreutils gawk"
 
 export ZOPEN_GIT_URL="https://github.com/autotools-mirror/automake.git"
 export ZOPEN_GIT_DEPS="git make m4 perl autoconf automake help2man makeinfo xz tar"


### PR DESCRIPTION
To fix this issue:
```
SKIP: t/get-sysconf.sh
XFAIL: t/pm/Cond2.pl
XFAIL: t/pm/Cond3.pl
PASS: t/pm/Condition.pl
SKIP: t/pm/Condition-t.pl
XFAIL: t/pm/DisjCon2.pl
XFAIL: t/pm/DisjCon3.pl
PASS: t/pm/DisjConditions.pl
SKIP: t/pm/DisjConditions-t.pl
PASS: t/pm/Version.pl
XFAIL: t/pm/Version2.pl
XFAIL: t/pm/Version3.pl
PASS: t/pm/Wrap.pl
trap: ./lib/tap-driver.sh 137: FSUM7327 signal number 13 not conventional
awk: line 369 (BEGIN): FSUM9393 line too long: limit 20000
tap-driver.sh: fatal: I/O or internal error
```